### PR TITLE
fix: GitHub Pages deployment - build portfolio app correctly

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -34,24 +34,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Fetch Inter variable font
-        run: |
-          mkdir -p fonts
-          curl -L -o fonts/Inter-roman.var.woff2 https://github.com/rsms/inter/releases/latest/download/Inter-roman.var.woff2
+      - name: Install Playwright for OG generation
+        run: npx playwright install chromium --with-deps
 
-      - name: Build (optimize + rev)
-        run: pnpm run build
+      - name: Sync projects from GitHub
+        run: pnpm projects:sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate OG images
+        run: pnpm og:gen
+
+      - name: Build portfolio
+        run: pnpm build:portfolio
+        env:
+          VITE_LAYOUT_ENABLED: "1"
 
       - name: Prepare artifact
         run: |
-          mkdir -p dist
-          shopt -s extglob
-          cp -r !(node_modules|.git|.github|dist) dist/
+          # dist-portfolio is the output directory
+          # Just upload it directly
+          ls -la dist-portfolio/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: dist-portfolio
 
   deploy:
     needs: build


### PR DESCRIPTION
## Problem
GitHub Pages deployment was failing with 'index.html not found' error.

## Root Cause
The workflow was calling generic \pnpm run build\ in a **monorepo with two apps**:
- **siteagent** (assistant UI)
- **portfolio** (www.leoklemet.com)

The generic build command doesn't know which app to build.

## Solution
Updated \.github/workflows/pages-deploy.yml\ to:
1. Call \pnpm build:portfolio\ instead of \pnpm run build\
2. Add project sync and OG image generation (matching portfolio-ci.yml)
3. Fix artifact path from \dist\ to \dist-portfolio\
4. Add Playwright installation for OG generation

## Testing
- [x] Verified build scripts in package.json
- [x] Compared with working portfolio-ci.yml workflow
- [ ] Will verify deployment after merge

## Related
- Fixes CI failures where all E2E tests timeout (production site was returning 530/502)
- Related to #ISSUE (if any)