### PR TITLE
Enable backend via api.leoklemet.com → portfolio-api.int:8000

### DIFF
--- a/.github/workflows/portfolio.yml
+++ b/.github/workflows/portfolio.yml
@@ -68,6 +68,7 @@ jobs:
             tests/e2e/seo.spec.ts \
             tests/e2e/csp.spec.ts \
             tests/e2e/resume-endpoints.spec.ts \
+            tests/e2e/api-ready.spec.ts \
             --project=chromium
 
       - name: Upload Playwright report

--- a/ASSISTANT_DOMAIN_CLEANUP_SUMMARY.md
+++ b/ASSISTANT_DOMAIN_CLEANUP_SUMMARY.md
@@ -1,0 +1,80 @@
+# assistant.ledger-mind.org References Cleanup
+
+## Context
+The domain `assistant.ledger-mind.org` **never existed**. It was incorrectly configured in nginx and documentation, causing 502 Bad Gateway errors.
+
+## Current Architecture (Correct)
+- **Frontend**: `www.leoklemet.com` (via Cloudflare Tunnel → nginx)
+- **Backend (public)**: `api.leoklemet.com` (via Cloudflare Tunnel → `portfolio-api.int:8000`)
+- **Backend (internal)**: `portfolio-api.int:8000` (Docker network alias)
+- **Same-origin proxy**: `www.leoklemet.com/api/` → `portfolio-api.int:8000/api/`
+
+## Grep Results Summary
+Found **~600 matches** for `assistant.ledger-mind.org` across the codebase:
+
+### Critical Files (Fixed in this PR)
+- ✅ `deploy/nginx.portfolio-dev.conf` - Changed to `portfolio-api.int:8000`
+- ✅ `apps/portfolio-ui/.env.production` - `VITE_SITE_ORIGIN` now set correctly
+- ✅ `cloudflared/config.yml` - Routes `api.leoklemet.com`, not assistant domain
+- ✅ `deploy/docker-compose.full.yml` - Uses internal alias
+- ✅ `deploy/docker-compose.portfolio-prod.yml` - Uses internal alias
+
+### Documentation Files (Historical - Low Priority)
+Most references are in documentation markdown files describing past deployment attempts:
+- `docs/DEPLOY.md`, `docs/PRODUCTION_DEPLOYMENT.md`, `docs/BACKEND_DEPLOYMENT.md`
+- `DEPLOY_TO_CLOUDFLARE.md`, `DEPLOY_TO_SERVER.md`, `DEPLOY_IMAGE.md`
+- `PRODUCTION_DEPLOYMENT_CHECKLIST.md`, `NEXT_STEPS.md`
+- `CLOUDFLARE_ACCESS_COMMANDS.md`, `CF_ACCESS_DEPLOYMENT_SUMMARY.md`
+- Many `*_COMPLETE.md` files documenting historical implementations
+
+### Active Nginx Configs (Needs Review)
+- `deploy/nginx.portfolio.conf` - **Contains** `assistant.ledger-mind.org` as server_name and proxy targets
+  - **Action**: This is an old production config, probably not in use
+  - **Verify**: Check which nginx config is actually deployed
+- `deploy/nginx.assistant.conf` - Dedicated config for assistant domain
+  - **Action**: Can be deleted (domain doesn't exist)
+
+### Active Workflow Files
+- `.github/workflows/portfolio.yml` (lines 113-114)
+- `.github/workflows/public-smoke.yml`
+- `.github/workflows/e2e.yml`
+- `.github/workflows/orchestrator-nightly.yml`
+  - **Action**: Update environment variables to use `www.leoklemet.com` or `api.leoklemet.com`
+
+### README.md
+Multiple examples showing `assistant.ledger-mind.org`:
+- Cloudflare Access examples
+- Admin endpoint examples
+- Agent endpoint examples
+  - **Action**: Update to `www.leoklemet.com` or `api.leoklemet.com`
+
+## Recommendation for This PR
+**Keep PR focused** - Only include critical deployment files already fixed:
+1. ✅ Docker compose files (network alias)
+2. ✅ Cloudflared config (ingress routing)
+3. ✅ Nginx portfolio-dev config (internal proxy)
+4. ✅ .env.production (frontend config)
+5. ✅ E2E test (api-ready.spec.ts)
+
+**Defer to follow-up PR** - Documentation and example cleanup:
+- Update all Markdown docs to reference new domains
+- Update GitHub Actions workflows
+- Update README examples
+- Remove obsolete nginx configs (`nginx.assistant.conf`, `nginx.portfolio.conf`)
+
+## Verification Commands (Post-Deployment)
+```powershell
+# Should work (new architecture)
+curl -I https://www.leoklemet.com/api/ready       # same-origin proxy
+curl -I https://api.leoklemet.com/api/ready       # direct backend
+
+# Should NOT work (domains don't exist or aren't routed)
+curl -I https://assistant.ledger-mind.org         # 503/530 (domain doesn't exist)
+```
+
+## Rollback Safety
+If this breaks, revert to:
+```env
+VITE_BACKEND_ENABLED=0
+```
+And comment out nginx proxy blocks again.

--- a/apps/portfolio-ui/.env.production
+++ b/apps/portfolio-ui/.env.production
@@ -20,4 +20,4 @@ VITE_LAYOUT_ENABLED=1
 # Backend API availability - enable in prod when backend is deployed
 # Flip this to 1 once backend is actually deployed and accessible
 # Set to 0 to disable backend calls and prevent 502 errors
-VITE_BACKEND_ENABLED=0
+VITE_BACKEND_ENABLED=1

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -3,6 +3,8 @@
 # credentials-file: /etc/cloudflared/db56892d-4879-4263-99bf-202d46b6aff9.json
 metrics: 0.0.0.0:2000
 ingress:
+  - hostname: api.leoklemet.com
+    service: http://portfolio-api.int:8000
   - hostname: app.ledger-mind.org
     service: http://nginx:80
   - service: http_status:404

--- a/deploy/docker-compose.full.yml
+++ b/deploy/docker-compose.full.yml
@@ -42,6 +42,11 @@ services:
     expose:
       - "8000"
     restart: unless-stopped
+    networks:
+      default:
+      infra_net:
+        aliases:
+          - portfolio-api.int
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
       interval: 30s
@@ -114,6 +119,10 @@ volumes:
   ollama:
   loki-data:
   promtail-positions:
+
+networks:
+  infra_net:
+    external: true
 
 secrets:
   openai_api_key:

--- a/deploy/docker-compose.portfolio-prod.yml
+++ b/deploy/docker-compose.portfolio-prod.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 # Portfolio Production Deployment Override
-# Deploy to: https://assistant.ledger-mind.org
+# Deploy to: https://www.leoklemet.com (frontend) + https://api.leoklemet.com (backend)
 # Frontend: Portfolio build (dist-portfolio/)
 # Backend: FastAPI + Ollama
 
@@ -11,8 +11,8 @@ services:
     container_name: portfolio-backend
     environment:
       # Production URLs
-      - ALLOWED_ORIGINS=https://assistant.ledger-mind.org
-      - BACKEND_URL=https://assistant.ledger-mind.org
+      - ALLOWED_ORIGINS=https://www.leoklemet.com,https://api.leoklemet.com
+      - BACKEND_URL=https://api.leoklemet.com
 
       # Database
       - RAG_DB=./data/rag.sqlite
@@ -45,6 +45,11 @@ services:
     ports:
       - "127.0.0.1:8001:8001"
     restart: unless-stopped
+    networks:
+      default:
+      infra_net:
+        aliases:
+          - portfolio-api.int
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ready"]
       interval: 30s

--- a/deploy/nginx.portfolio-dev.conf
+++ b/deploy/nginx.portfolio-dev.conf
@@ -81,51 +81,33 @@ server {
     add_header Content-Disposition "inline";
   }
 
-  # Chat endpoints DISABLED (assistant.ledger-mind.org doesn't exist yet)
-  # Uncomment and configure when backend is actually deployed
-  # location /chat/stream {
-  #   set $upstream_host your-actual-backend-domain.com;
-  #   proxy_pass https://$upstream_host/chat/stream;
-  #   proxy_http_version 1.1;
-  #   proxy_set_header Host $upstream_host;
-  #   proxy_ssl_server_name on;
-  #   proxy_set_header Connection '';
-  #   proxy_buffering off;
-  #   proxy_request_buffering off;
-  #   proxy_read_timeout 3600s;
-  #   proxy_set_header X-Real-IP $remote_addr;
-  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  #   proxy_set_header X-Forwarded-Proto $scheme;
-  #   proxy_set_header Cookie $http_cookie;
-  # }
+  # --- API (same-origin proxy to portfolio backend) ---
+  location /api/ {
+    proxy_pass         http://portfolio-api.int:8000/api/;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 30s;
+  }
 
-  # location /chat {
-  #   set $upstream_host your-actual-backend-domain.com;
-  #   proxy_pass https://$upstream_host/chat;
-  #   proxy_http_version 1.1;
-  #   proxy_set_header Host $upstream_host;
-  #   proxy_ssl_server_name on;
-  #   proxy_set_header Connection '';
-  #   proxy_set_header X-Real-IP $remote_addr;
-  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  #   proxy_set_header X-Forwarded-Proto $scheme;
-  #   proxy_set_header Cookie $http_cookie;
-  # }
+  # --- Chat (websocket/HTTP) ---
+  location /chat {
+    proxy_pass         http://portfolio-api.int:8000/chat;
+    proxy_set_header   Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header   Connection "";
+    proxy_read_timeout 300s;
+  }
 
-  # API proxy -> DISABLED (assistant.ledger-mind.org doesn't exist yet)
-  # Uncomment and configure when backend is actually deployed
-  # location /api/ {
-  #   set $upstream_host your-actual-backend-domain.com;
-  #   proxy_pass https://$upstream_host/api/;
-  #   proxy_http_version 1.1;
-  #   proxy_set_header Host $upstream_host;
-  #   proxy_ssl_server_name on;
-  #   proxy_set_header Connection '';
-  #   proxy_set_header X-Real-IP $remote_addr;
-  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  #   proxy_set_header X-Forwarded-Proto $scheme;
-  #   proxy_set_header Cookie $http_cookie;
-  # }
+  # --- Chat SSE ---
+  location /chat/stream {
+    proxy_pass         http://portfolio-api.int:8000/chat/stream;
+    proxy_set_header   Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header   Connection "";
+    proxy_buffering    off;
+    proxy_read_timeout 300s;
+  }
 
   # Health check endpoint
   location = /healthz {

--- a/tests/e2e/api-ready.spec.ts
+++ b/tests/e2e/api-ready.spec.ts
@@ -1,0 +1,7 @@
+// tests/e2e/api-ready.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('api /ready is reachable via same-origin proxy', async ({ request }) => {
+  const res = await request.get('/api/ready');
+  expect(res.status()).toBe(200);
+});


### PR DESCRIPTION
# Enable backend via api.leoklemet.com → portfolio-api.int:8000

## Summary
Re-enables backend API after fixing 502 Bad Gateway errors caused by proxying to non-existent `assistant.ledger-mind.org` domain.

## Changes
- **Network alias**: Add `portfolio-api.int:8000` to backend service in Docker compose
- **Cloudflare Tunnel**: Route `api.leoklemet.com` → `http://portfolio-api.int:8000`
- **Nginx proxy**: Re-enable `/api/`, `/chat`, `/chat/stream` blocks with internal routing
- **Frontend flag**: Set `VITE_BACKEND_ENABLED=1` in `.env.production`
- **E2E test**: Add minimal `/api/ready` spec to validate same-origin proxy
- **CORS update**: `ALLOWED_ORIGINS=https://www.leoklemet.com,https://api.leoklemet.com`
- **Cleanup docs**: Document obsolete `assistant.*` references for future PR

## Architecture

### Before (Broken)
```
Browser → www.leoklemet.com/api/ready
          ↓ (nginx proxy)
       assistant.ledger-mind.org/api/ready  ❌ DNS fails → 502 Bad Gateway
```

### After (Fixed)
```
Browser → www.leoklemet.com/api/ready
          ↓ (nginx same-origin proxy)
       portfolio-api.int:8000/api/ready  ✅ Internal Docker network

OR

Direct → api.leoklemet.com/api/ready
         ↓ (Cloudflare Tunnel)
       portfolio-api.int:8000/api/ready  ✅ Public backend access
```

## Testing
- ✅ E2E test added: `tests/e2e/api-ready.spec.ts`
- ✅ Local validation: Nginx config syntax verified
- ✅ Smoke test commands (post-merge):
  ```powershell
  # Same-origin proxy (frontend → nginx → backend)
  curl -I https://www.leoklemet.com/api/ready

  # Direct backend (public)
  curl -I https://api.leoklemet.com/api/ready

  # Static site still healthy
  curl -I https://www.leoklemet.com
  ```

## Post-Merge Actions
1. **Restart cloudflared**: `docker restart infra-cloudflared-1` (to pick up new `api.leoklemet.com` ingress)
2. **Run smoke tests** (commands above)
3. **Verify backend live**: Check /api/ready returns 200 OK
4. **Monitor logs** for errors

## Rollback Plan
If anything breaks:
1. Set `VITE_BACKEND_ENABLED=0` in `apps/portfolio-ui/.env.production`
2. Comment out nginx proxy blocks in `deploy/nginx.portfolio-dev.conf`
3. Commit and trigger Agent Refresh workflow
4. Site will revert to static-only (no backend calls)

## Notes
- **Domain cleanup**: ~600 `assistant.ledger-mind.org` references found (mostly docs)
- **Defer to follow-up PR**: Documentation updates, workflow env vars, README examples
- **Worker-based refresh flow**: Kept as-is (out of scope for this PR)
- **Internal alias**: `portfolio-api.int:8000` eliminates external DNS dependencies
